### PR TITLE
yaml fix for A1

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,5 +1,10 @@
 name: assignment-test
-on: [push]
+on: 
+    push:
+        tags-ignore:
+            - '*'
+        branches:
+            - '*'
 jobs:
     unit-test:
         container: cuaesd/aesd-autotest:unit-test


### PR DESCRIPTION
Changes for A1 merged into https://github.com/cu-ecen-aeld/assignments-complete-private/tree/assignment-1-complete

Created a tag in assignments-1-complete branch https://github.com/cu-ecen-aeld/assignments-complete-private/releases/tag/yaml-fix-a1-test
This did not trigger the actions runner whereas a tag on the master branch has triggered runner as expected https://github.com/cu-ecen-aeld/assignments-complete-private/actions