### PR TITLE
Fix Assignment 1 Finder Test

### DIFF
--- a/finder-app/finder-test.sh
+++ b/finder-app/finder-test.sh
@@ -34,7 +34,7 @@ rm -rf "${WRITEDIR}"
 # create $WRITEDIR if not assignment1
 assignment=`cat ../conf/assignment.txt`
 
-if [ $assignment != 'assignment1' ]
+if [ $assignment = 'assignment1' ]
 then
 	mkdir -p "$WRITEDIR"
 


### PR DESCRIPTION
Currently, finder-test.sh creates a temporary test directory when the the program isn't configured to assignment 1.  However, this probably should not be the case. 

See issue posted on Coursera:

https://www.coursera.org/learn/linux-system-programming-introduction-to-buildroot/discussions/weeks/1/threads/nznuPzXEEe6qcgp0u5G9Fw/replies/WcQRxTo6Ee6qcgp0u5G9Fw